### PR TITLE
Redundancy Cleanup

### DIFF
--- a/app/application/routes.ini
+++ b/app/application/routes.ini
@@ -1,6 +1,6 @@
 [routes]
-GET|POST /@module/@method = modules\@module\controllers\Controller->@method
+GET|POST /@module/@method = modules\@module\Controller->@method
 
 [maps]
-/@module = modules\@module\controllers\Controller
+/@module = modules\@module\Controller
 

--- a/app/modules/ex1/controller.php
+++ b/app/modules/ex1/controller.php
@@ -1,0 +1,9 @@
+<?php
+namespace modules\ex1;
+class Controller extends \Controller {
+	function get() {
+		$model = loadModel("model");
+		$this->f3->set('output', $model->returnOutput());
+		echo render('index');
+	}
+}

--- a/app/modules/ex2/controller.php
+++ b/app/modules/ex2/controller.php
@@ -1,0 +1,32 @@
+<?php
+namespace modules\ex2;
+class Controller extends \Controller {
+
+	function get() {
+		
+		$example = loadModel('model');
+		$this->f3->set('output', $example->returnOutput());
+		
+		echo render('index');
+	}
+	
+	function method_example() {
+		if($this->f3->get('VERB') == "POST") {
+			$this->method_example_post();
+			return;
+		}
+		$this->f3->set('output', "Example Two - Method Example");
+		echo render('index');
+	}
+	
+	function method_example_post() {
+		$this->f3->set('output', "User Value (method_example): ".$_POST['text']);
+		echo render('index');
+	}
+	
+	function post() {
+		$this->f3->set('output', "User Value (index): ".$_POST['text']);
+		echo render('index');
+	}
+	
+}

--- a/index.php
+++ b/index.php
@@ -11,7 +11,7 @@ $f3 = Base::instance();
 $f3->config('config.ini');
 $f3->config('app/application/routes.ini');
 
-$f3->map('/', "modules\\{$f3->get('defaultModule')}\\controllers\\Controller");
+$f3->map('/', "modules\\{$f3->get('defaultModule')}\\Controller");
 
 //php imports
 require_once("app/application/php_functions.php");

--- a/readme.md
+++ b/readme.md
@@ -41,19 +41,17 @@ I've attempted to make the GF3 structure easy to follow. Most edits will be made
 		routes.ini
 | modules
 	| ex1
-		| controllers
-			controller.php
 		| models
 			model.php
 		| views
 			index.htm
+		controller.php
 	| ex2
-		| controllers
-			controller.php
 		| models
 			model.php
 		| views
 			index.htm
+		controller.php
 controller.php
 ```
 
@@ -67,7 +65,7 @@ Here is a simple class skeleton:
 
 ```
 <?php
-namespace modules\MODULE_NAME\controllers;
+namespace modules\MODULE_NAME;
 class controller extends \Controller {
 	function get() {
 		$example = loadModel('model');
@@ -76,7 +74,7 @@ class controller extends \Controller {
 }
 ```
 
-Classes have a namespace "modules\MODULE_NAME\controllers", so F3 knows which class is a controller or a model.
+Classes have a namespace "modules\MODULE_NAME", so F3 knows which class is a controller or a model.
 
 Note: MODULE_NAME should be equal to the directory name the module resides in. So if you have a module called "login", it would be stored at app/modules/login/ and MODULE_NAME would be "login"
 


### PR DESCRIPTION
Got rid of a redundant folder requirement inside modules where it used to require a folder "controllers" to house the module controller, but the module controller was moved to the root of the controller and the controllers folder requirement has been removed.